### PR TITLE
Added BurningOkr 

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ List of software for managing your OKRs. This list was made using this Product H
 - [Workboard](http://www.producthunt.com/tech/workboard)
 - [15five](http://www.15five.com/)
 - [Zugata](http://www.zugata.com/)
+- [BurningOkr](https://github.com/BurningOKR/BurningOKR)
 
 ## Contributing
 


### PR DESCRIPTION
Added BurningOkr to the Software list in the README.
BurningOkr is a OpenSource projekt on GitHub which implemented the OKR framework.